### PR TITLE
initialize some local int variables with 0

### DIFF
--- a/grimes.c
+++ b/grimes.c
@@ -72,7 +72,7 @@ void reaper_exit(reaper_t * reaper, int status)
 // is the child process that we spawned get its exit status and exit this program
 int reaper_reap(reaper_t * reaper)
 {
-	int status, child_exited, child_status = 0;
+	int status = 0, child_exited = 0, child_status = 0;
 	for (;;) {
 		pid_t pid = waitpid(-1, &status, WNOHANG);
 		switch (pid) {


### PR DESCRIPTION
Given the following Dockerfile:

```
FROM alpine
ADD init.sh /init.sh
CMD ["/init.sh"]
```

Contents of init.sh:

```
#!/bin/sh
echo "Starting ..."
sh -c "sleep 1 &"
sleep 1.2
echo Started
```

Before this change, the container would exit before the line "echo Started".
After some attempts I found the problem get fixed whith this patch.
It seems that the variable `child_exited` may get garbage value if not
explicitly initialized.

Signed-off-by: Shijiang Wei <mountkin@gmail.com>